### PR TITLE
WIP: Fix operand error when calculating the price

### DIFF
--- a/src/fixed_path_gas_station/fixed_path_gas_station.py
+++ b/src/fixed_path_gas_station/fixed_path_gas_station.py
@@ -188,7 +188,7 @@ class FixedPathGasStation:
         self.fill_liters = fill_liters
 
     def compute_price(self):
-        self.price = sum([cost * liters for cost, liters in zip(self.path['cost'], self.fill_liters)])
+        self.price = sum([float(cost) * liters for cost, liters in zip(self.path['cost'], self.fill_liters)])
 
     def __str__(self):
         display_format = "{}: {}"


### PR DESCRIPTION
Fix error which occurs when multiplying cost and liters because "*" is not defined for 'decimal.Decimal' (cost) and 'float' (liters). @feeds I hope you didn't use decimal on purpose.